### PR TITLE
Use Freeleech25 instead of Internal indexer flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Prowlarr indexer for [Seadex](https://releases.moe/) torrents. Always get the best Seadex release.
 
 > [!NOTE]
-> Automatic Searching requires indexer flag `internal` to be unused for now
+> Automatic Searching requires indexer flag `Freeleech25` to be unused for now
 
 ## Docker Compose
 
@@ -52,7 +52,7 @@ In Sonarr or Radarr:
 1. Go to **Settings → Custom Formats**
 2. Create a new **Custom Format** named `Seadex`
 3. Add an **Indexer Flag Condition**
-4. Set both **Name** and **Flag** to `Internal` (leave boxes unchecked)
+4. Set both **Name** and **Flag** to `Freeleech25` (leave boxes unchecked)
 5. Click **Test** and **Save**
 6. Go to **Settings → Profiles**
 7. Click on your profile and give a high score to Seadex (Ex: 5000)

--- a/src/torznab.rs
+++ b/src/torznab.rs
@@ -37,7 +37,7 @@ pub struct TorznabSubCategory {
     pub name: &'static str,
 }
 
-const TAG: &str = "internal";
+const TAG: &str = "freeleech25";
 const DESC: &str = "Description";
 
 pub const ANIME_CATEGORY: TorznabCategory = TorznabCategory {


### PR DESCRIPTION
`Internal` is a very common flag so to avoid conflicts we'll use a much less popular flag `Freeleech25`