### PR TITLE
fix: don't timeout on mappings download

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -19,6 +19,13 @@ use crate::{AppState, SharedAppState};
 /// Timeout applied to every outbound HTTP client
 pub const TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Timeouts for the mappings download client. The shared [`TIMEOUT`] is a total
+/// request timeout, too tight for the large (~9 MB) mappings asset served via a
+/// redirect to GitHub's CDN. Instead we bound connect and per-read stalls, which
+/// lets a healthy-but-slow download run to completion.
+pub const MAPPINGS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub const MAPPINGS_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn router(state: SharedAppState) -> Router {
     Router::new()
         .route("/health", get(health))

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -69,7 +69,8 @@ impl PlexAniBridgeMappings {
 
         let path = data_path.join("mappings.json");
         let client = Client::builder()
-            .timeout(http::TIMEOUT)
+            .connect_timeout(http::MAPPINGS_CONNECT_TIMEOUT)
+            .read_timeout(http::MAPPINGS_READ_TIMEOUT)
             .user_agent(format!("seadexerr/{}", env!("CARGO_PKG_VERSION")))
             .build()
             .context("failed to construct PlexAniBridge HTTP client")?;


### PR DESCRIPTION
add a `read_timeout` with higher time to prevent timeout before download completes.