### PR TITLE
feat: new scoring system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1441,6 +1442,15 @@ checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
  "serde_core",
 ]
 
@@ -1744,6 +1754,45 @@ dependencies = [
  "rustls",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2286,6 +2335,18 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_with = "3.20.0"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["formatting", "parsing"] }
+toml = "0.9"
 tokio = { version = "1.52.3", features = [
     "fs",
     "macros",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ services:
       - SONARR_API_KEY=<your api key here>
       - RADARR_BASE_URL=http://localhost:7878/
       - RADARR_API_KEY=<your api key here>
+    volumes:
+      - ./data:/data
 ```
 
 <details>
@@ -34,85 +36,11 @@ Most can be left as default
 | `SEADEXERR_PUBLIC_BASE_URL` | (optional; falls back to `http://{SEADEXERR_HOST}:{SEADEXERR_PORT}`) | Base URL advertised in the Torznab feed. Set when running behind a reverse proxy.                            |
 | `SEADEXERR_SKIP_DEBAND`     | `false`                                                              | **Deprecated** - use `exclude_tags` in `scoring.toml`. Skip releases with the `Deband Required` tag.         |
 | `SEADEXERR_PREFER`          | `best`                                                               | **Deprecated** - use `scoring.toml`. Prefer `best`, `dual_audio`, or `smallest` when multiple options exist. |
-| `AB_PASSKEY`                | (optional)                                                           | AnimeBytes passkey. Enables AnimeBytes releases. See [AnimeBytes Support](#animebytes-support).              |
+| `AB_PASSKEY`                | (optional)                                                           | AnimeBytes passkey. See [AnimeBytes Support](#animebytes-support).                                           |
 
 \* At least one of `SONARR_API_KEY` or `RADARR_API_KEY` must be provided. If only one is provided, the other service is disabled.
 
 </details>
-
-## AnimeBytes Support
-
-Seadexerr can also serve AnimeBytes releases listed on Seadex. Set
-`AB_PASSKEY` to your AnimeBytes passkey to enable it.
-
-> [!NOTE]
-> I rely on issue reports to find and fix AnimeBytes-specific breakage.
-
-## Release Scoring
-
-When several releases exist for the same entry, Seadexerr scores each one and
-advertises the highest scorer(s) to Sonarr/Radarr with a boosted seeder count so
-they win the grab. Scoring is configured in a `scoring.toml` file placed in the
-data directory (mount a volume to `/data`):
-
-```yaml
-services:
-  seadexerr:
-    image: ghcr.io/ryder-c/seadexerr:latest
-    container_name: seadexerr
-    environment:
-      - SONARR_BASE_URL=http://localhost:8989/
-      - SONARR_API_KEY=<your api key here>
-    volumes:
-      - ./data:/data
-```
-
-```toml
-# data/scoring.toml
-#
-# Each release's score is the sum of the weights below for everything it
-# matches. The highest scorer(s) get the seeder boost; ties all win. Weights
-# are integers and may be negative (penalties). Unlisted tags score 0.
-
-# Category weights (releases.moe's per-release booleans)
-best = 100          # release marked "Best" on releases.moe
-dual_audio = 50     # release marked Dual Audio
-
-# Size axis. The release size is normalized across the candidates to [0, 1]
-# (smallest = 1.0, largest = 0.0) and multiplied by this weight.
-#   > 0  favors smaller releases
-#   < 0  favors larger releases
-#   0    ignores size entirely
-size_weight = 30
-
-# Tags removed from results entirely (not just deprioritized). Match the exact
-# releases.moe label. Replaces the deprecated SEADEXERR_SKIP_DEBAND.
-exclude_tags = ["Deband Required"]
-
-# Per-tag weights, keyed by the exact releases.moe tag label.
-[tags]
-"HDR"                = 20
-"Dolby Vision"       = 20
-"YUV444P"            = 10
-"Deband Recommended" = 5
-"VFR"                = -10
-"Misplaced Special"  = -20
-"Patch Required"     = -30
-"Broken"             = -1000
-```
-
-Every field has a default, so a minimal file only needs what you care about:
-
-```toml
-best = 100
-
-[tags]
-"HDR" = 20
-```
-
-If no `scoring.toml` is present, Seadexerr defaults to preferring the Best
-release. The deprecated `SEADEXERR_PREFER` / `SEADEXERR_SKIP_DEBAND` variables
-still work as a fallback, but log a warning when set.
 
 ## Prowlarr & Sonarr Integration
 
@@ -133,6 +61,23 @@ In Sonarr or Radarr:
 5. Click **Test** and **Save**
 6. Go to **Settings → Profiles**
 7. Click on your profile and give a high score to Seadex (Ex: 5000)
+
+## Release Scoring
+
+When several releases exist for the same entry, Seadexerr picks the one you'd
+prefer. By default it favors the Best release. To change what wins, make a
+`scoring.toml` in your data directory.
+
+See [`example_scoring.toml`](example_scoring.toml) for a fully commented file.
+Every option has a default, so keep only what you care about.
+
+## AnimeBytes Support
+
+Seadexerr can also serve AnimeBytes releases listed on Seadex. Set
+`AB_PASSKEY` to your AnimeBytes passkey to enable it.
+
+> [!NOTE]
+> I rely on issue reports to find and fix AnimeBytes-specific breakage.
 
 This project uses [AniBridge Mappings](https://github.com/anibridge/anibridge-mappings).
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ services:
 <summary>Advanced Configuration</summary>
 Most can be left as default
 
-| Variable                    | Default                                                              | Purpose                                                                                         |
-| --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `SONARR_API_KEY`            | (optional\*)                                                         | Sonarr API key used to resolve series titles. Required if using Sonarr.                         |
-| `SONARR_BASE_URL`           | `http://localhost:8989/`                                             | Base URL for your Sonarr instance.                                                              |
-| `RADARR_API_KEY`            | (optional\*)                                                         | Radarr API key used to resolve movie titles. Required if using Radarr.                          |
-| `RADARR_BASE_URL`           | `http://localhost:7878/`                                             | Base URL for your Radarr instance.                                                              |
-| `SEADEXERR_HOST`            | `0.0.0.0`                                                            | Interface the HTTP server listens on.                                                           |
-| `SEADEXERR_PORT`            | `6767`                                                               | TCP port Seadexerr binds to. Must be a valid `u16`.                                             |
-| `SEADEXERR_PUBLIC_BASE_URL` | (optional; falls back to `http://{SEADEXERR_HOST}:{SEADEXERR_PORT}`) | Base URL advertised in the Torznab feed. Set when running behind a reverse proxy.               |
-| `SEADEXERR_SKIP_DEBAND`     | `false`                                                              | Skip releases with the `Deband Required` tag.                                                   |
-| `SEADEXERR_PREFER`          | `best`                                                               | Release to prefer when multiple options are available: `best`, `dual_audio`, or `smallest`.     |
-| `AB_PASSKEY`                | (optional)                                                           | AnimeBytes passkey. Enables AnimeBytes releases. See [AnimeBytes Support](#animebytes-support). |
+| Variable                    | Default                                                              | Purpose                                                                                                      |
+| --------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `SONARR_API_KEY`            | (optional\*)                                                         | Sonarr API key used to resolve series titles. Required if using Sonarr.                                      |
+| `SONARR_BASE_URL`           | `http://localhost:8989/`                                             | Base URL for your Sonarr instance.                                                                           |
+| `RADARR_API_KEY`            | (optional\*)                                                         | Radarr API key used to resolve movie titles. Required if using Radarr.                                       |
+| `RADARR_BASE_URL`           | `http://localhost:7878/`                                             | Base URL for your Radarr instance.                                                                           |
+| `SEADEXERR_HOST`            | `0.0.0.0`                                                            | Interface the HTTP server listens on.                                                                        |
+| `SEADEXERR_PORT`            | `6767`                                                               | TCP port Seadexerr binds to. Must be a valid `u16`.                                                          |
+| `SEADEXERR_PUBLIC_BASE_URL` | (optional; falls back to `http://{SEADEXERR_HOST}:{SEADEXERR_PORT}`) | Base URL advertised in the Torznab feed. Set when running behind a reverse proxy.                            |
+| `SEADEXERR_SKIP_DEBAND`     | `false`                                                              | **Deprecated** - use `exclude_tags` in `scoring.toml`. Skip releases with the `Deband Required` tag.         |
+| `SEADEXERR_PREFER`          | `best`                                                               | **Deprecated** - use `scoring.toml`. Prefer `best`, `dual_audio`, or `smallest` when multiple options exist. |
+| `AB_PASSKEY`                | (optional)                                                           | AnimeBytes passkey. Enables AnimeBytes releases. See [AnimeBytes Support](#animebytes-support).              |
 
 \* At least one of `SONARR_API_KEY` or `RADARR_API_KEY` must be provided. If only one is provided, the other service is disabled.
 
@@ -47,6 +47,72 @@ Seadexerr can also serve AnimeBytes releases listed on Seadex. Set
 
 > [!NOTE]
 > I rely on issue reports to find and fix AnimeBytes-specific breakage.
+
+## Release Scoring
+
+When several releases exist for the same entry, Seadexerr scores each one and
+advertises the highest scorer(s) to Sonarr/Radarr with a boosted seeder count so
+they win the grab. Scoring is configured in a `scoring.toml` file placed in the
+data directory (mount a volume to `/data`):
+
+```yaml
+services:
+  seadexerr:
+    image: ghcr.io/ryder-c/seadexerr:latest
+    container_name: seadexerr
+    environment:
+      - SONARR_BASE_URL=http://localhost:8989/
+      - SONARR_API_KEY=<your api key here>
+    volumes:
+      - ./data:/data
+```
+
+```toml
+# data/scoring.toml
+#
+# Each release's score is the sum of the weights below for everything it
+# matches. The highest scorer(s) get the seeder boost; ties all win. Weights
+# are integers and may be negative (penalties). Unlisted tags score 0.
+
+# Category weights (releases.moe's per-release booleans)
+best = 100          # release marked "Best" on releases.moe
+dual_audio = 50     # release marked Dual Audio
+
+# Size axis. The release size is normalized across the candidates to [0, 1]
+# (smallest = 1.0, largest = 0.0) and multiplied by this weight.
+#   > 0  favors smaller releases
+#   < 0  favors larger releases
+#   0    ignores size entirely
+size_weight = 30
+
+# Tags removed from results entirely (not just deprioritized). Match the exact
+# releases.moe label. Replaces the deprecated SEADEXERR_SKIP_DEBAND.
+exclude_tags = ["Deband Required"]
+
+# Per-tag weights, keyed by the exact releases.moe tag label.
+[tags]
+"HDR"                = 20
+"Dolby Vision"       = 20
+"YUV444P"            = 10
+"Deband Recommended" = 5
+"VFR"                = -10
+"Misplaced Special"  = -20
+"Patch Required"     = -30
+"Broken"             = -1000
+```
+
+Every field has a default, so a minimal file only needs what you care about:
+
+```toml
+best = 100
+
+[tags]
+"HDR" = 20
+```
+
+If no `scoring.toml` is present, Seadexerr defaults to preferring the Best
+release. The deprecated `SEADEXERR_PREFER` / `SEADEXERR_SKIP_DEBAND` variables
+still work as a fallback, but log a warning when set.
 
 ## Prowlarr & Sonarr Integration
 

--- a/example_scoring.toml
+++ b/example_scoring.toml
@@ -1,0 +1,34 @@
+# Example scoring.toml
+#
+# Place this file in your data directory as `scoring.toml` to customize which
+# releases Seadexerr prefers. Every field has a default, so you only need to
+# include what you care about. Delete the rest.
+#
+# Each release's score is the sum of the weights below for everything it
+# matches. The highest scorer(s) win. Weights are integers and may be negative.
+# Unlisted tags score 0.
+
+# Category weights
+best = 100          # release marked "Best" on releases.moe
+dual_audio = 50     # release marked Dual Audio
+
+# Size axis. The release size is normalized across the candidates to [0, 1]
+# (smallest = 1.0, largest = 0.0) and multiplied by this weight.
+#   > 0  favors smaller releases
+#   < 0  favors larger releases
+#   0    ignores size entirely
+size_weight = 30
+
+# Tags removed from results entirely. Match the exact releases.moe label.
+exclude_tags = ["Deband Required"]
+
+# Per-tag weights, uses the exact releases.moe tag label.
+[tags]
+"HDR"                = 20
+"Dolby Vision"       = 20
+"YUV444P"            = 10
+"Deband Recommended" = 5
+"VFR"                = -10
+"Misplaced Special"  = -20
+"Broken"             = -30
+"Patch Required"     = -1000

--- a/example_scoring.toml
+++ b/example_scoring.toml
@@ -13,11 +13,13 @@ best = 100          # release marked "Best" on releases.moe
 dual_audio = 50     # release marked Dual Audio
 
 # Size axis. The release size is normalized across the candidates to [0, 1]
-# (smallest = 1.0, largest = 0.0) and multiplied by this weight.
-#   > 0  favors smaller releases
-#   < 0  favors larger releases
+# (smallest = 0.0, largest = 1.0) and multiplied by this weight.
+# size_weight = 30 -> the largest releases score is increased by 30 (favoring larger)
+# size_weight = -30 -> the largest releases score is decreased by 30 (favoring smaller)
+#   < 0  favors smaller releases
+#   > 0  favors larger releases
 #   0    ignores size entirely
-size_weight = 30
+size_weight = -30
 
 # Tags removed from results entirely. Match the exact releases.moe label.
 exclude_tags = ["Deband Required"]

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {

--- a/src/anilist.rs
+++ b/src/anilist.rs
@@ -14,7 +14,6 @@ query MediaById($idIn: [Int], $perPage: Int) {
   Page(perPage: $perPage) {
     media(id_in: $idIn) {
       id
-      type
       format
     }
   }
@@ -47,7 +46,7 @@ impl AniListClient {
         unique.sort_unstable();
         unique.dedup();
 
-        for chunk in unique.chunks(MAX_IDS_PER_REQUEST.max(1)) {
+        for chunk in unique.chunks(MAX_IDS_PER_REQUEST) {
             let request = GraphqlRequest {
                 query: MEDIA_QUERY,
                 variables: GraphqlVariables {
@@ -157,8 +156,6 @@ struct GraphqlPage {
 #[derive(Debug, Deserialize)]
 struct GraphqlMedia {
     id: i64,
-    #[serde(rename = "type")]
-    _media_type: Option<String>,
     format: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,3 @@
-//! Application configuration loaded from environment variables.
-//!
-//! At least one of `SONARR_API_KEY` or `RADARR_API_KEY` must be set, everything
-//! else has a default.
-
 use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
@@ -12,22 +7,11 @@ use anyhow::{Result, bail};
 use reqwest::Url;
 use serde::Deserialize;
 
+use crate::scoring::{LegacyPreference, ScoringConfig};
+
 pub const APPLICATION_TITLE: &str = "Seadexerr";
 pub const APPLICATION_DESCRIPTION: &str = "Indexer bridge for releases.moe";
 pub const DATA_PATH: &str = "data";
-
-/// How to pick between multiple eligible releases for the same entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum AnimePreference {
-    /// Use the release marked as Best on releases.moe
-    #[default]
-    Best,
-    /// Prefer releases marked Dual Audio on releases.moe
-    DualAudio,
-    /// Prefer releases with the smallest file size
-    Smallest,
-}
 
 #[derive(Deserialize)]
 struct EnvConfig {
@@ -42,13 +26,11 @@ struct EnvConfig {
     radarr_api_key: Option<String>,
     #[serde(default = "default_radarr_url")]
     radarr_base_url: Url,
-
-    // Extra configuration
-    #[serde(default)]
-    seadexerr_skip_deband: bool,
-    #[serde(default)]
-    seadexerr_prefer: AnimePreference,
     ab_passkey: Option<String>,
+
+    // Deprecated, kept only to migrate setups without a scoring.toml.
+    seadexerr_skip_deband: Option<bool>,
+    seadexerr_prefer: Option<LegacyPreference>,
 }
 
 #[derive(Clone, Debug)]
@@ -57,8 +39,7 @@ pub struct AppConfig {
     pub public_base_url: Option<Url>,
     pub sonarr: Option<SonarrConfig>,
     pub radarr: Option<RadarrConfig>,
-    pub skip_deband: bool,
-    pub preference: AnimePreference,
+    pub scoring: ScoringConfig,
     pub ab_passkey: Option<String>,
 }
 
@@ -99,21 +80,22 @@ impl TryFrom<EnvConfig> for AppConfig {
             api_key,
         });
 
-        let skip_deband = seadexerr_skip_deband;
-
-        let preference = seadexerr_prefer;
-
         if sonarr.is_none() && radarr.is_none() {
             bail!("at least one of Sonarr or Radarr configuration must be provided");
         }
+
+        let scoring = ScoringConfig::load(
+            &default_data_path(),
+            seadexerr_prefer,
+            seadexerr_skip_deband,
+        )?;
 
         Ok(AppConfig {
             listen_addr,
             public_base_url,
             sonarr,
             radarr,
-            skip_deband,
-            preference,
+            scoring,
             ab_passkey,
         })
     }
@@ -164,8 +146,8 @@ mod tests {
             sonarr_base_url: default_sonarr_url(),
             radarr_api_key: None,
             radarr_base_url: default_radarr_url(),
-            seadexerr_skip_deband: false,
-            seadexerr_prefer: AnimePreference::Best,
+            seadexerr_skip_deband: None,
+            seadexerr_prefer: None,
             ab_passkey: None,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,8 +68,6 @@ impl TryFrom<EnvConfig> for AppConfig {
 
         let listen_addr = SocketAddr::new(seadexerr_host, seadexerr_port);
 
-        let public_base_url = seadexerr_public_base_url;
-
         let sonarr = sonarr_api_key.map(|api_key| SonarrConfig {
             url: sonarr_base_url,
             api_key,
@@ -92,7 +90,7 @@ impl TryFrom<EnvConfig> for AppConfig {
 
         Ok(AppConfig {
             listen_addr,
-            public_base_url,
+            public_base_url: seadexerr_public_base_url,
             sonarr,
             radarr,
             scoring,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod http;
 mod mapping;
 mod radarr;
 mod releases;
+mod scoring;
 mod service;
 mod sonarr;
 mod torznab;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,27 +44,21 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to initialise PlexAniBridge mappings store")?;
 
-    let sonarr = if let Some(sonarr_config) = &config.sonarr {
-        Some(
-            SonarrClient::new(
-                http_client.clone(),
-                sonarr_config.clone(),
-                data_path.clone(),
-            )
-            .context("failed to construct Sonarr client")?,
-        )
-    } else {
-        None
-    };
+    let sonarr = config
+        .sonarr
+        .as_ref()
+        .map(|sonarr_config| {
+            SonarrClient::new(http_client.clone(), sonarr_config.clone(), data_path.clone())
+        })
+        .transpose()
+        .context("failed to construct Sonarr client")?;
 
-    let radarr = if let Some(radarr_config) = &config.radarr {
-        Some(
-            RadarrClient::new(http_client, radarr_config.clone(), data_path)
-                .context("failed to construct Radarr client")?,
-        )
-    } else {
-        None
-    };
+    let radarr = config
+        .radarr
+        .as_ref()
+        .map(|radarr_config| RadarrClient::new(http_client, radarr_config.clone(), data_path))
+        .transpose()
+        .context("failed to construct Radarr client")?;
 
     let state = Arc::new(SearchService::new(
         anilist, sonarr, radarr, releases, mappings, config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,11 @@ async fn main() -> anyhow::Result<()> {
         .sonarr
         .as_ref()
         .map(|sonarr_config| {
-            SonarrClient::new(http_client.clone(), sonarr_config.clone(), data_path.clone())
+            SonarrClient::new(
+                http_client.clone(),
+                sonarr_config.clone(),
+                data_path.clone(),
+            )
         })
         .transpose()
         .context("failed to construct Sonarr client")?;

--- a/src/radarr.rs
+++ b/src/radarr.rs
@@ -178,9 +178,9 @@ impl RadarrClient {
             path: self.cache_path.clone(),
         })?;
 
-        if let Err(_err) = result {
+        if let Err(err) = result {
             return Err(RadarrError::CacheWrite {
-                source: std::io::Error::other("failed to persist cache"),
+                source: std::io::Error::other(err.to_string()),
                 path: self.cache_path.clone(),
             });
         }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -131,16 +131,12 @@ impl ReleasesClient {
         }
 
         let unique: HashSet<String> = torrent_ids.iter().cloned().collect();
-        if unique.is_empty() {
-            return Ok(result);
-        }
-
         let mut unique_ids: Vec<String> = unique.into_iter().collect();
         unique_ids.sort_unstable();
 
         const CHUNK_SIZE: usize = 20;
 
-        for chunk in unique_ids.chunks(CHUNK_SIZE.max(1)) {
+        for chunk in unique_ids.chunks(CHUNK_SIZE) {
             let filter = chunk
                 .iter()
                 .map(|id| format!("(trs~'{}')", id))

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -9,7 +9,6 @@ use tracing::trace;
 
 const RELEASES_BASE_URL: &str = "https://releases.moe/api/";
 const PAGE_SIZE: usize = 100;
-const DEBAND_TAG: &str = "Deband Required";
 
 #[derive(Debug, Clone)]
 pub struct ReleasesClient {
@@ -224,10 +223,6 @@ pub struct Torrent {
 }
 
 impl Torrent {
-    pub fn is_deband(&self) -> bool {
-        self.tags.iter().any(|tag| tag == DEBAND_TAG)
-    }
-
     fn from_record(
         record: TorrentRecord,
         anilist_id: Option<i64>,

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,0 +1,294 @@
+use std::{collections::HashMap, path::Path};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::releases::Torrent;
+
+pub const SCORING_FILE: &str = "scoring.toml";
+
+/// The scoring table that decides which release(s) get the seeder boost
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScoringConfig {
+    /// Weight for releases marked Best on releases.moe
+    #[serde(default)]
+    pub best: i32,
+    /// Weight for releases marked Dual Audio on releases.moe
+    #[serde(default)]
+    pub dual_audio: i32,
+    /// Applied to the size factor: `>0` favors smaller, `<0` larger, `0` ignores
+    #[serde(default)]
+    pub size_weight: i32,
+    /// Tags that remove a release from results entirely (exact releases.moe label)
+    #[serde(default)]
+    pub exclude_tags: Vec<String>,
+    /// Per-tag weights, keyed by the exact releases.moe tag label
+    #[serde(default)]
+    pub tags: HashMap<String, i32>,
+}
+
+impl ScoringConfig {
+    /// Load the scoring table from `<data_path>/scoring.toml` with prefer best default
+    pub fn load(
+        data_path: &Path,
+        prefer: Option<LegacyPreference>,
+        skip_deband: Option<bool>,
+    ) -> Result<Self> {
+        if prefer.is_some() {
+            warn!("SEADEXERR_PREFER is deprecated -- configure scoring in {SCORING_FILE} instead");
+        }
+        if skip_deband.is_some() {
+            warn!(
+                "SEADEXERR_SKIP_DEBAND is deprecated -- use exclude_tags in {SCORING_FILE} instead"
+            );
+        }
+
+        let path = data_path.join(SCORING_FILE);
+
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => toml::from_str(&contents)
+                .with_context(|| format!("failed to parse {}", path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::from_legacy(
+                prefer.unwrap_or_default(),
+                skip_deband.unwrap_or(false),
+            )),
+            Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
+        }
+    }
+
+    /// Build an equivalent scoring profile from the deprecated env settings.
+    fn from_legacy(prefer: LegacyPreference, skip_deband: bool) -> Self {
+        let (best, dual_audio, size_weight) = match prefer {
+            LegacyPreference::Best => (1, 0, 0),
+            LegacyPreference::DualAudio => (0, 1, 0),
+            LegacyPreference::Smallest => (0, 0, 1),
+        };
+
+        let exclude_tags = if skip_deband {
+            vec![DEBAND_REQUIRED_TAG.to_string()]
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            best,
+            dual_audio,
+            size_weight,
+            exclude_tags,
+            tags: HashMap::new(),
+        }
+    }
+
+    /// Whether a release should be removed from results based on its tags.
+    pub fn is_excluded(&self, tags: &[String]) -> bool {
+        self.exclude_tags
+            .iter()
+            .any(|excluded| tags.iter().any(|tag| tag == excluded))
+    }
+
+    /// For each release, whether it is among the highest scorers in the set.
+    pub fn priorities(&self, releases: &[Torrent]) -> Vec<bool> {
+        if releases.is_empty() {
+            return Vec::new();
+        }
+
+        let max_size = releases.iter().map(|r| r.size_bytes).max().unwrap_or(0);
+        let min_size = releases.iter().map(|r| r.size_bytes).min().unwrap_or(0);
+        let span = (max_size - min_size) as i64;
+
+        let scores: Vec<i64> = releases
+            .iter()
+            .map(|release| {
+                let mut base = 0i64;
+
+                if release.is_best {
+                    base += i64::from(self.best);
+                }
+                if release.dual_audio {
+                    base += i64::from(self.dual_audio);
+                }
+                for tag in &release.tags {
+                    if let Some(tag_weight) = self.tags.get(tag) {
+                        base += i64::from(*tag_weight);
+                    }
+                }
+
+                if span == 0 {
+                    base
+                } else {
+                    // Scaled by `span`, so this is a large comparison key, not a real score.
+                    base * span
+                        + i64::from(self.size_weight) * (max_size - release.size_bytes) as i64
+                }
+            })
+            .collect();
+
+        let best = scores.iter().copied().max().unwrap_or(0);
+        scores.iter().map(|&score| score == best).collect()
+    }
+}
+
+/// The exact releases.moe label for the Deband Required tag.
+const DEBAND_REQUIRED_TAG: &str = "Deband Required";
+
+/// The deprecated `SEADEXERR_PREFER` value, kept only to migrate old setups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyPreference {
+    #[default]
+    Best,
+    DualAudio,
+    Smallest,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::releases::{Torrent, Tracker};
+
+    fn torrent(id: &str, size: u64) -> Torrent {
+        Torrent {
+            id: id.to_string(),
+            download_url: String::new(),
+            source_url: String::new(),
+            info_hash: None,
+            published: None,
+            files: Vec::new(),
+            size_bytes: size,
+            is_best: false,
+            dual_audio: false,
+            tags: Vec::new(),
+            anilist_id: None,
+            tracker: Tracker::Nyaa,
+        }
+    }
+
+    #[test]
+    fn parses_table() {
+        let toml = r#"
+            best = 100
+            dual_audio = 50
+            size_weight = 30
+            exclude_tags = ["Deband Required"]
+
+            [tags]
+            "HDR" = 20
+            "VFR" = -10
+        "#;
+
+        let scoring: ScoringConfig = toml::from_str(toml).unwrap();
+        assert_eq!(scoring.best, 100);
+        assert_eq!(scoring.dual_audio, 50);
+        assert_eq!(scoring.size_weight, 30);
+        assert_eq!(scoring.exclude_tags, vec!["Deband Required".to_string()]);
+        assert_eq!(scoring.tags.get("HDR"), Some(&20));
+        assert_eq!(scoring.tags.get("VFR"), Some(&-10));
+    }
+
+    #[test]
+    fn minimal_table_uses_defaults() {
+        let scoring: ScoringConfig = toml::from_str("best = 100\n").unwrap();
+        assert_eq!(scoring.best, 100);
+        assert_eq!(scoring.dual_audio, 0);
+        assert!(scoring.exclude_tags.is_empty());
+        assert!(scoring.tags.is_empty());
+    }
+
+    #[test]
+    fn best_weight_wins() {
+        let scoring = ScoringConfig {
+            best: 100,
+            ..Default::default()
+        };
+        let mut a = torrent("a", 100);
+        a.is_best = true;
+        let b = torrent("b", 50);
+
+        assert_eq!(scoring.priorities(&[a, b]), vec![true, false]);
+    }
+
+    #[test]
+    fn size_weight_favors_smaller() {
+        let scoring = ScoringConfig {
+            size_weight: 30,
+            ..Default::default()
+        };
+        let big = torrent("big", 1000);
+        let small = torrent("small", 100);
+
+        assert_eq!(scoring.priorities(&[big, small]), vec![false, true]);
+    }
+
+    #[test]
+    fn ties_all_win() {
+        let scoring = ScoringConfig {
+            best: 100,
+            ..Default::default()
+        };
+        let mut a = torrent("a", 100);
+        a.is_best = true;
+        let mut b = torrent("b", 100);
+        b.is_best = true;
+
+        assert_eq!(scoring.priorities(&[a, b]), vec![true, true]);
+    }
+
+    #[test]
+    fn empty_set_has_no_priorities() {
+        let scoring = ScoringConfig::default();
+        assert!(scoring.priorities(&[]).is_empty());
+    }
+
+    #[test]
+    fn exclude_matches_exact_tag() {
+        let scoring = ScoringConfig {
+            exclude_tags: vec!["Deband Required".to_string()],
+            ..Default::default()
+        };
+        assert!(scoring.is_excluded(&["Deband Required".to_string()]));
+        assert!(!scoring.is_excluded(&["HDR".to_string()]));
+        assert!(!scoring.is_excluded(&[]));
+    }
+
+    #[test]
+    fn load_without_file_or_env_prefers_best() {
+        let dir = tempfile::tempdir().unwrap();
+        let scoring = ScoringConfig::load(dir.path(), None, None).unwrap();
+        assert_eq!(scoring.best, 1);
+        assert_eq!(scoring.dual_audio, 0);
+        assert_eq!(scoring.size_weight, 0);
+        assert!(scoring.exclude_tags.is_empty());
+    }
+
+    #[test]
+    fn load_reads_file_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(SCORING_FILE), "best = 42\n").unwrap();
+        let scoring = ScoringConfig::load(dir.path(), None, None).unwrap();
+        assert_eq!(scoring.best, 42);
+    }
+
+    #[test]
+    fn legacy_best_maps_to_best_weight() {
+        let scoring = ScoringConfig::from_legacy(LegacyPreference::Best, false);
+        assert_eq!(scoring.best, 1);
+        assert_eq!(scoring.dual_audio, 0);
+        assert_eq!(scoring.size_weight, 0);
+        assert!(scoring.exclude_tags.is_empty());
+    }
+
+    #[test]
+    fn legacy_smallest_maps_to_size_weight() {
+        let scoring = ScoringConfig::from_legacy(LegacyPreference::Smallest, false);
+        assert_eq!(scoring.size_weight, 1);
+    }
+
+    #[test]
+    fn legacy_skip_deband_maps_to_exclude() {
+        let scoring = ScoringConfig::from_legacy(LegacyPreference::DualAudio, true);
+        assert_eq!(scoring.dual_audio, 1);
+        assert_eq!(scoring.exclude_tags, vec!["Deband Required".to_string()]);
+    }
+}

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -24,7 +24,7 @@ pub struct ScoringConfig {
     /// Weight for releases marked Dual Audio on releases.moe
     #[serde(default)]
     pub dual_audio: i32,
-    /// Applied to the size factor: `>0` favors smaller, `<0` larger, `0` ignores
+    /// Applied to the size factor: `<0` favors smaller, `>0` larger, `0` ignores
     #[serde(default)]
     pub size_weight: i32,
     /// Tags that remove a release from results entirely (exact releases.moe label)
@@ -84,7 +84,7 @@ impl ScoringConfig {
         let (best, dual_audio, size_weight) = match prefer {
             LegacyPreference::Best => (default_best(), 0, 0),
             LegacyPreference::DualAudio => (0, 1, 0),
-            LegacyPreference::Smallest => (0, 0, 1),
+            LegacyPreference::Smallest => (0, 0, -1),
         };
 
         let exclude_tags = if skip_deband {
@@ -141,7 +141,7 @@ impl ScoringConfig {
                 } else {
                     // Scaled by `span`, so this is a large comparison key, not a real score.
                     base * span
-                        + i64::from(self.size_weight) * (max_size - release.size_bytes) as i64
+                        + i64::from(self.size_weight) * (release.size_bytes - min_size) as i64
                 }
             })
             .collect();
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn size_weight_favors_smaller() {
         let scoring = ScoringConfig {
-            size_weight: 30,
+            size_weight: -30,
             ..Default::default()
         };
         let big = torrent("big", 1000);
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn legacy_smallest_maps_to_size_weight() {
         let scoring = ScoringConfig::from_legacy(LegacyPreference::Smallest, false);
-        assert_eq!(scoring.size_weight, 1);
+        assert_eq!(scoring.size_weight, -1);
     }
 
     #[test]

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -2,18 +2,24 @@ use std::{collections::HashMap, path::Path};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::releases::Torrent;
 
 pub const SCORING_FILE: &str = "scoring.toml";
 
+/// Default weight for releases marked Best, applied when `best` is unset.
+/// Large enough to dominate, so an empty/absent table just prioritizes Best.
+fn default_best() -> i32 {
+    100
+}
+
 /// The scoring table that decides which release(s) get the seeder boost
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ScoringConfig {
     /// Weight for releases marked Best on releases.moe
-    #[serde(default)]
+    #[serde(default = "default_best")]
     pub best: i32,
     /// Weight for releases marked Dual Audio on releases.moe
     #[serde(default)]
@@ -27,6 +33,18 @@ pub struct ScoringConfig {
     /// Per-tag weights, keyed by the exact releases.moe tag label
     #[serde(default)]
     pub tags: HashMap<String, i32>,
+}
+
+impl Default for ScoringConfig {
+    fn default() -> Self {
+        Self {
+            best: default_best(),
+            dual_audio: 0,
+            size_weight: 0,
+            exclude_tags: Vec::new(),
+            tags: HashMap::new(),
+        }
+    }
 }
 
 impl ScoringConfig {
@@ -48,8 +66,11 @@ impl ScoringConfig {
         let path = data_path.join(SCORING_FILE);
 
         match std::fs::read_to_string(&path) {
-            Ok(contents) => toml::from_str(&contents)
-                .with_context(|| format!("failed to parse {}", path.display())),
+            Ok(contents) => {
+                info!("loaded scoring config from {}", path.display());
+                toml::from_str(&contents)
+                    .with_context(|| format!("failed to parse {}", path.display()))
+            }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::from_legacy(
                 prefer.unwrap_or_default(),
                 skip_deband.unwrap_or(false),
@@ -61,7 +82,7 @@ impl ScoringConfig {
     /// Build an equivalent scoring profile from the deprecated env settings.
     fn from_legacy(prefer: LegacyPreference, skip_deband: bool) -> Self {
         let (best, dual_audio, size_weight) = match prefer {
-            LegacyPreference::Best => (1, 0, 0),
+            LegacyPreference::Best => (default_best(), 0, 0),
             LegacyPreference::DualAudio => (0, 1, 0),
             LegacyPreference::Smallest => (0, 0, 1),
         };
@@ -256,7 +277,18 @@ mod tests {
     fn load_without_file_or_env_prefers_best() {
         let dir = tempfile::tempdir().unwrap();
         let scoring = ScoringConfig::load(dir.path(), None, None).unwrap();
-        assert_eq!(scoring.best, 1);
+        assert_eq!(scoring.best, default_best());
+        assert_eq!(scoring.dual_audio, 0);
+        assert_eq!(scoring.size_weight, 0);
+        assert!(scoring.exclude_tags.is_empty());
+    }
+
+    #[test]
+    fn load_empty_file_matches_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(SCORING_FILE), "\n  \n").unwrap();
+        let scoring = ScoringConfig::load(dir.path(), None, None).unwrap();
+        assert_eq!(scoring.best, default_best());
         assert_eq!(scoring.dual_audio, 0);
         assert_eq!(scoring.size_weight, 0);
         assert!(scoring.exclude_tags.is_empty());
@@ -273,7 +305,7 @@ mod tests {
     #[test]
     fn legacy_best_maps_to_best_weight() {
         let scoring = ScoringConfig::from_legacy(LegacyPreference::Best, false);
-        assert_eq!(scoring.best, 1);
+        assert_eq!(scoring.best, default_best());
         assert_eq!(scoring.dual_audio, 0);
         assert_eq!(scoring.size_weight, 0);
         assert!(scoring.exclude_tags.is_empty());

--- a/src/service.rs
+++ b/src/service.rs
@@ -626,12 +626,11 @@ impl SearchService {
     }
 
     fn is_excluded(&self, release: &Torrent) -> bool {
-        if self.config.scoring.is_excluded(&release.tags) {
+        let excluded = self.config.scoring.is_excluded(&release.tags);
+        if excluded {
             trace!(torrent_id = %release.id, "excluding torrent due to excluded tag");
-            true
-        } else {
-            false
         }
+        excluded
     }
 
     fn build_torznab_item(

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::anilist::{AniListClient, AniListError, MediaFormat};
-use crate::config::{AnimePreference, AppConfig};
+use crate::config::AppConfig;
 use crate::mapping::{PlexAniBridgeMappings, TvdbMapping, parse_season_key};
 use crate::radarr::{RadarrClient, RadarrError};
 use crate::releases::{ReleasesClient, ReleasesError, Torrent, Tracker};
@@ -594,7 +594,7 @@ impl SearchService {
     ) -> Vec<TorznabItem> {
         torrents
             .into_iter()
-            .filter(|release| !self.skip_due_to_deband(release))
+            .filter(|release| !self.is_excluded(release))
             .map(|release| {
                 let seeders = priority_seeders(release.tracker, release.is_best);
                 self.build_torznab_item(release, title.clone(), categories.clone(), seeders)
@@ -610,10 +610,10 @@ impl SearchService {
     ) -> Vec<TorznabItem> {
         let filtered: Vec<Torrent> = torrents
             .into_iter()
-            .filter(|release| !self.skip_due_to_deband(release))
+            .filter(|release| !self.is_excluded(release))
             .collect();
 
-        let priorities = self.compute_priorities(&filtered);
+        let priorities = self.config.scoring.priorities(&filtered);
 
         filtered
             .into_iter()
@@ -625,29 +625,12 @@ impl SearchService {
             .collect()
     }
 
-    fn skip_due_to_deband(&self, release: &Torrent) -> bool {
-        if self.config.skip_deband && release.is_deband() {
-            trace!(torrent_id = %release.id, "skipping torrent due to Deband tag");
+    fn is_excluded(&self, release: &Torrent) -> bool {
+        if self.config.scoring.is_excluded(&release.tags) {
+            trace!(torrent_id = %release.id, "excluding torrent due to excluded tag");
             true
         } else {
             false
-        }
-    }
-
-    fn compute_priorities(&self, releases: &[Torrent]) -> Vec<bool> {
-        match self.config.preference {
-            AnimePreference::Best => releases.iter().map(|r| r.is_best).collect(),
-            AnimePreference::DualAudio => releases.iter().map(|r| r.dual_audio).collect(),
-            AnimePreference::Smallest => {
-                let smallest_idx = releases
-                    .iter()
-                    .enumerate()
-                    .min_by_key(|(_, r)| r.size_bytes)
-                    .map(|(i, _)| i);
-                (0..releases.len())
-                    .map(|i| Some(i) == smallest_idx)
-                    .collect()
-            }
         }
     }
 

--- a/src/sonarr.rs
+++ b/src/sonarr.rs
@@ -166,11 +166,9 @@ impl SonarrClient {
             path: self.cache_path.clone(),
         })?;
 
-        if let Err(_err) = result {
-            // For simplicity, map any persistence error to CacheWrite. We avoid trying to
-            // downcast boxed errors back to concrete types here.
+        if let Err(err) = result {
             return Err(SonarrError::CacheWrite {
-                source: std::io::Error::other("failed to persist cache"),
+                source: std::io::Error::other(err.to_string()),
                 path: self.cache_path.clone(),
             });
         }


### PR DESCRIPTION
Introduced a new `scoring.toml` file that can be used to score torrents based on their tags from releases.moe

Example:
```toml
# data/scoring.toml
#
# Each release's score is the sum of the weights below for everything it
# matches. The highest scorer(s) get the seeder boost; ties all win. Weights
# are integers and may be negative (penalties). Unlisted tags score 0.

# Category weights (releases.moe's per-release booleans)
best = 100          # release marked "Best" on releases.moe
dual_audio = 50     # release marked Dual Audio

# Size axis. The release size is normalized across the candidates to [0, 1]
# (smallest = 1.0, largest = 0.0) and multiplied by this weight.
#   > 0  favors smaller releases
#   < 0  favors larger releases
#   0    ignores size entirely
size_weight = 30

# Tags removed from results entirely (not just deprioritized). Match the exact
# releases.moe label. Replaces the deprecated SEADEXERR_SKIP_DEBAND.
exclude_tags = ["Deband Required"]

# Per-tag weights, keyed by the exact releases.moe tag label.
[tags]
"HDR"                = 20
"Dolby Vision"       = 20
"YUV444P"            = 10
"Deband Recommended" = -5
"Misplaced Special"  = 0
"VFR"                = -10
"Patch Required"     = -30
"Broken"             = -1000
```

Everything in the `[tags]` section is matched against tags specified directly on [the releases.moe about page](https://releases.moe/about/).

fixes #31