### PR TITLE
feat: add AnimeBytes tracker support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "seadexerr"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seadexerr"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,21 +23,30 @@ services:
 <summary>Advanced Configuration</summary>
 Most can be left as default
 
-| Variable                      | Default                                                              | Purpose                                                                           |
-| ----------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `SONARR_API_KEY`              | (optional\*)                                                         | Sonarr API key used to resolve series titles. Required if using Sonarr.           |
-| `SONARR_BASE_URL`             | `http://localhost:8989/`                                             | Base URL for your Sonarr instance.                                                |
-| `RADARR_API_KEY`              | (optional\*)                                                         | Radarr API key used to resolve movie titles. Required if using Radarr.            |
-| `RADARR_BASE_URL`             | `http://localhost:7878/`                                             | Base URL for your Radarr instance.                                                |
-| `SEADEXERR_HOST`              | `0.0.0.0`                                                            | Interface the HTTP server listens on.                                             |
-| `SEADEXERR_PORT`              | `6767`                                                               | TCP port Seadexerr binds to. Must be a valid `u16`.                               |
-| `SEADEXERR_PUBLIC_BASE_URL`   | (optional; falls back to `http://{SEADEXERR_HOST}:{SEADEXERR_PORT}`) | Base URL advertised in the Torznab feed. Set when running behind a reverse proxy. |
-| `SEADEXERR_SKIP_DEBAND`       | `false`                                                              | Skip releases with the `Deband Required` tag.                                     |
-| `SEADEXERR_PREFER`            | `best`                                                               | Release to prefer when multiple options are available: `best`, `dual_audio`, or `smallest`. |
+| Variable                    | Default                                                              | Purpose                                                                                         |
+| --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `SONARR_API_KEY`            | (optional\*)                                                         | Sonarr API key used to resolve series titles. Required if using Sonarr.                         |
+| `SONARR_BASE_URL`           | `http://localhost:8989/`                                             | Base URL for your Sonarr instance.                                                              |
+| `RADARR_API_KEY`            | (optional\*)                                                         | Radarr API key used to resolve movie titles. Required if using Radarr.                          |
+| `RADARR_BASE_URL`           | `http://localhost:7878/`                                             | Base URL for your Radarr instance.                                                              |
+| `SEADEXERR_HOST`            | `0.0.0.0`                                                            | Interface the HTTP server listens on.                                                           |
+| `SEADEXERR_PORT`            | `6767`                                                               | TCP port Seadexerr binds to. Must be a valid `u16`.                                             |
+| `SEADEXERR_PUBLIC_BASE_URL` | (optional; falls back to `http://{SEADEXERR_HOST}:{SEADEXERR_PORT}`) | Base URL advertised in the Torznab feed. Set when running behind a reverse proxy.               |
+| `SEADEXERR_SKIP_DEBAND`     | `false`                                                              | Skip releases with the `Deband Required` tag.                                                   |
+| `SEADEXERR_PREFER`          | `best`                                                               | Release to prefer when multiple options are available: `best`, `dual_audio`, or `smallest`.     |
+| `AB_PASSKEY`                | (optional)                                                           | AnimeBytes passkey. Enables AnimeBytes releases. See [AnimeBytes Support](#animebytes-support). |
 
 \* At least one of `SONARR_API_KEY` or `RADARR_API_KEY` must be provided. If only one is provided, the other service is disabled.
 
 </details>
+
+## AnimeBytes Support
+
+Seadexerr can also serve AnimeBytes releases listed on Seadex. Set
+`AB_PASSKEY` to your AnimeBytes passkey to enable it.
+
+> [!NOTE]
+> I rely on issue reports to find and fix AnimeBytes-specific breakage.
 
 ## Prowlarr & Sonarr Integration
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ struct EnvConfig {
     seadexerr_skip_deband: bool,
     #[serde(default)]
     seadexerr_prefer: AnimePreference,
+    ab_passkey: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -58,6 +59,7 @@ pub struct AppConfig {
     pub radarr: Option<RadarrConfig>,
     pub skip_deband: bool,
     pub preference: AnimePreference,
+    pub ab_passkey: Option<String>,
 }
 
 impl AppConfig {
@@ -80,6 +82,7 @@ impl TryFrom<EnvConfig> for AppConfig {
             radarr_base_url,
             seadexerr_skip_deband,
             seadexerr_prefer,
+            ab_passkey,
         } = env_config;
 
         let listen_addr = SocketAddr::new(seadexerr_host, seadexerr_port);
@@ -100,6 +103,8 @@ impl TryFrom<EnvConfig> for AppConfig {
 
         let preference = seadexerr_prefer;
 
+        let ab_passkey = ab_passkey;
+
         if sonarr.is_none() && radarr.is_none() {
             bail!("at least one of Sonarr or Radarr configuration must be provided");
         }
@@ -111,6 +116,7 @@ impl TryFrom<EnvConfig> for AppConfig {
             radarr,
             skip_deband,
             preference,
+            ab_passkey,
         })
     }
 }
@@ -162,6 +168,7 @@ mod tests {
             radarr_base_url: default_radarr_url(),
             seadexerr_skip_deband: false,
             seadexerr_prefer: AnimePreference::Best,
+            ab_passkey: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,8 +103,6 @@ impl TryFrom<EnvConfig> for AppConfig {
 
         let preference = seadexerr_prefer;
 
-        let ab_passkey = ab_passkey;
-
         if sonarr.is_none() && radarr.is_none() {
             bail!("at least one of Sonarr or Radarr configuration must be provided");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ async fn main() -> anyhow::Result<()> {
 
     let http_client = http::client().context("failed to construct shared HTTP client")?;
 
-    let releases =
-        ReleasesClient::new(http_client.clone()).context("failed to construct releases.moe client")?;
+    let releases = ReleasesClient::new(http_client.clone(), config.ab_passkey.as_deref())
+        .context("failed to construct releases.moe client")?;
 
     let anilist =
         AniListClient::new(http_client.clone()).context("failed to construct AniList client")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,12 @@ async fn main() -> anyhow::Result<()> {
 
     let sonarr = if let Some(sonarr_config) = &config.sonarr {
         Some(
-            SonarrClient::new(http_client.clone(), sonarr_config.clone(), data_path.clone())
-                .context("failed to construct Sonarr client")?,
+            SonarrClient::new(
+                http_client.clone(),
+                sonarr_config.clone(),
+                data_path.clone(),
+            )
+            .context("failed to construct Sonarr client")?,
         )
     } else {
         None

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -100,7 +100,6 @@ impl ReleasesClient {
     }
 
     fn entries_to_torrents(entries: Vec<EntryRecord>, ab_passkey: Option<&str>) -> Vec<Torrent> {
-        let ab_enabled = ab_passkey.is_some();
         entries
             .into_iter()
             .flat_map(|entry| {
@@ -109,13 +108,16 @@ impl ReleasesClient {
                     expand.trs.into_iter().map(move |record| (al_id, record))
                 })
             })
-            .filter(|(_, record)| {
-                record.tracker == "Nyaa" || (ab_enabled && record.tracker == "AB")
-            })
-            .filter(|(_, record)| !record.tags.contains(&"Incomplete".to_string()))
             .filter_map(|(al_id, record)| {
-                let download_url = rewritten_download_url(&record, ab_passkey)?;
-                Some(Torrent::from_record(record, al_id, download_url))
+                let tracker = Tracker::from_name(&record.tracker)?;
+                if !tracker.is_enabled(ab_passkey) {
+                    return None;
+                }
+                if record.tags.contains(&"Incomplete".to_string()) {
+                    return None;
+                }
+                let download_url = tracker.download_url(&record.url, ab_passkey)?;
+                Some(Torrent::from_record(record, al_id, tracker, download_url))
             })
             .collect()
     }
@@ -172,7 +174,7 @@ impl ReleasesClient {
                 let Some(al_id) = entry.al_id else { continue };
 
                 for record in expand.trs {
-                    if record.tracker != "Nyaa" && record.tracker != "AB" {
+                    if Tracker::from_name(&record.tracker).is_none() {
                         continue;
                     }
 
@@ -218,7 +220,7 @@ pub struct Torrent {
     pub dual_audio: bool,
     pub tags: Vec<String>,
     pub anilist_id: Option<i64>,
-    pub tracker: String,
+    pub tracker: Tracker,
 }
 
 impl Torrent {
@@ -226,13 +228,13 @@ impl Torrent {
         self.tags.iter().any(|tag| tag == DEBAND_TAG)
     }
 
-    fn from_record(record: TorrentRecord, anilist_id: Option<i64>, download_url: String) -> Self {
-        let source_url = if record.tracker == "AB" && record.url.starts_with('/') {
-            format!("https://animebytes.tv{}", record.url)
-        } else {
-            record.url.clone()
-        };
-        let tracker = record.tracker.clone();
+    fn from_record(
+        record: TorrentRecord,
+        anilist_id: Option<i64>,
+        tracker: Tracker,
+        download_url: String,
+    ) -> Self {
+        let source_url = tracker.absolute_source_url(&record.url);
         let size_bytes = record.files.iter().map(|f| f.length).sum::<u64>();
         Torrent {
             id: record.id,
@@ -292,25 +294,61 @@ fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
     OffsetDateTime::parse(&normalized, &Rfc3339).ok()
 }
 
-fn rewritten_download_url(record: &TorrentRecord, ab_passkey: Option<&str>) -> Option<String> {
-    if record.tracker == "AB" {
-        let passkey = ab_passkey?;
-        let torrentid = extract_id(record.url.as_str(), Some(&record.tracker))?;
-        Some(format!(
-            "https://animebytes.tv/torrent/{torrentid}/download/{passkey}"
-        ))
-    } else {
-        let id = extract_id(record.url.as_str(), None)?;
-        Some(format!("https://nyaa.si/download/{id}.torrent"))
+/// A torrent tracker we know how to construct download/source URLs for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tracker {
+    Nyaa,
+    AnimeBytes,
+}
+
+impl Tracker {
+    /// Maps a releases.moe `tracker` value to a known tracker, or `None` if unsupported.
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "Nyaa" => Some(Tracker::Nyaa),
+            "AB" => Some(Tracker::AnimeBytes),
+            _ => None,
+        }
+    }
+
+    /// Whether this tracker can be used given the current configuration.
+    fn is_enabled(self, ab_passkey: Option<&str>) -> bool {
+        match self {
+            Tracker::Nyaa => true,
+            Tracker::AnimeBytes => ab_passkey.is_some(),
+        }
+    }
+
+    /// Builds the `.torrent` download URL for a record, or `None` if the record's
+    /// source URL doesn't contain a usable id (or the passkey is missing for AB).
+    fn download_url(self, record_url: &str, ab_passkey: Option<&str>) -> Option<String> {
+        match self {
+            Tracker::Nyaa => {
+                let id = extract_id(record_url, "/view/")?;
+                Some(format!("https://nyaa.si/download/{id}.torrent"))
+            }
+            Tracker::AnimeBytes => {
+                let passkey = ab_passkey?;
+                let torrentid = extract_id(record_url, "torrentid=")?;
+                Some(format!(
+                    "https://animebytes.tv/torrent/{torrentid}/download/{passkey}"
+                ))
+            }
+        }
+    }
+
+    /// Resolves a record's (possibly relative) source URL to an absolute one.
+    fn absolute_source_url(self, record_url: &str) -> String {
+        match self {
+            Tracker::AnimeBytes if record_url.starts_with('/') => {
+                format!("https://animebytes.tv{record_url}")
+            }
+            _ => record_url.to_string(),
+        }
     }
 }
 
-fn extract_id<'a>(url: &'a str, tracker: Option<&str>) -> Option<&'a str> {
-    let needle = if tracker == Some("AB") {
-        "torrentid="
-    } else {
-        "/view/"
-    };
+fn extract_id<'a>(url: &'a str, needle: &str) -> Option<&'a str> {
     let start = url.find(needle)? + needle.len();
     let rest = &url[start..];
     let id = rest.split(['?', '#', '/', '&']).next().unwrap_or("");
@@ -384,49 +422,52 @@ mod tests {
     #[test]
     fn extracts_nyaa_id() {
         assert_eq!(
-            extract_id("https://nyaa.si/view/12345", None),
+            extract_id("https://nyaa.si/view/12345", "/view/"),
             Some("12345")
         );
         assert_eq!(
-            extract_id("https://nyaa.si/view/12345?foo=bar", None),
+            extract_id("https://nyaa.si/view/12345?foo=bar", "/view/"),
             Some("12345")
         );
         assert_eq!(
-            extract_id("https://nyaa.si/view/12345#section", None),
+            extract_id("https://nyaa.si/view/12345#section", "/view/"),
             Some("12345")
         );
         assert_eq!(
-            extract_id("https://nyaa.si/view/12345/extra", None),
+            extract_id("https://nyaa.si/view/12345/extra", "/view/"),
             Some("12345")
         );
-        assert_eq!(extract_id("https://nyaa.si/view/abc", None), None);
-        assert_eq!(extract_id("https://nyaa.si/view/12a45", None), None);
-        assert_eq!(extract_id("https://nyaa.si/something/12345", None), None);
-        assert_eq!(extract_id("", None), None);
+        assert_eq!(extract_id("https://nyaa.si/view/abc", "/view/"), None);
+        assert_eq!(extract_id("https://nyaa.si/view/12a45", "/view/"), None);
+        assert_eq!(
+            extract_id("https://nyaa.si/something/12345", "/view/"),
+            None
+        );
+        assert_eq!(extract_id("", "/view/"), None);
     }
 
     #[test]
     fn extracts_ab_torrent_id() {
         assert_eq!(
-            extract_id("/torrents.php?id=70543&torrentid=1143533", Some("AB")),
+            extract_id("/torrents.php?id=70543&torrentid=1143533", "torrentid="),
             Some("1143533")
         );
         assert_eq!(
             extract_id(
                 "/torrents.php?id=70543&torrentid=1143533&extra=1",
-                Some("AB")
+                "torrentid="
             ),
             Some("1143533")
         );
         assert_eq!(
             extract_id(
                 "/torrents.php?id=70543&torrentid=1143533#section",
-                Some("AB")
+                "torrentid="
             ),
             Some("1143533")
         );
-        assert_eq!(extract_id("/torrents.php?id=70543", Some("AB")), None);
-        assert_eq!(extract_id("", Some("AB")), None);
+        assert_eq!(extract_id("/torrents.php?id=70543", "torrentid="), None);
+        assert_eq!(extract_id("", "torrentid="), None);
     }
 
     #[test]
@@ -449,7 +490,7 @@ mod tests {
         };
         let download_url = "https://nyaa.si/download/1.torrent".to_string();
         assert_eq!(
-            Torrent::from_record(with_files, None, download_url).size_bytes,
+            Torrent::from_record(with_files, None, Tracker::Nyaa, download_url).size_bytes,
             600
         );
 
@@ -461,7 +502,7 @@ mod tests {
         let updated = OffsetDateTime::parse("2024-02-02T00:00:00Z", &Rfc3339).unwrap();
         let download_url = "https://nyaa.si/download/1.torrent".to_string();
         assert_eq!(
-            Torrent::from_record(both_timestamps, None, download_url).published,
+            Torrent::from_record(both_timestamps, None, Tracker::Nyaa, download_url).published,
             Some(updated)
         );
 
@@ -473,7 +514,7 @@ mod tests {
         let created = OffsetDateTime::parse("2024-01-01T00:00:00Z", &Rfc3339).unwrap();
         let download_url = "https://nyaa.si/download/1.torrent".to_string();
         assert_eq!(
-            Torrent::from_record(only_created, None, download_url).published,
+            Torrent::from_record(only_created, None, Tracker::Nyaa, download_url).published,
             Some(created)
         );
 
@@ -482,16 +523,16 @@ mod tests {
             ..make_torrent_record("1")
         };
         let download_url = "https://nyaa.si/download/9876.torrent".to_string();
-        let torrent = Torrent::from_record(with_nyaa_url, None, download_url.clone());
+        let torrent =
+            Torrent::from_record(with_nyaa_url, None, Tracker::Nyaa, download_url.clone());
         assert_eq!(torrent.download_url, download_url);
         assert_eq!(torrent.source_url, "https://nyaa.si/view/9876");
-        assert_eq!(torrent.tracker, "Nyaa");
+        assert_eq!(torrent.tracker, Tracker::Nyaa);
 
         let with_ab_url = make_ab_torrent_record("70543", "1143533");
-        let ab_download_url =
-            "https://animebytes.tv/torrent/1143533/download/test".to_string();
-        let torrent = Torrent::from_record(with_ab_url, None, ab_download_url);
-        assert_eq!(torrent.tracker, "AB");
+        let ab_download_url = "https://animebytes.tv/torrent/1143533/download/test".to_string();
+        let torrent = Torrent::from_record(with_ab_url, None, Tracker::AnimeBytes, ab_download_url);
+        assert_eq!(torrent.tracker, Tracker::AnimeBytes);
         assert_eq!(
             torrent.source_url,
             "https://animebytes.tv/torrents.php?id=70543&torrentid=1143533"
@@ -558,8 +599,8 @@ mod tests {
         )];
         let torrents = ReleasesClient::entries_to_torrents(entries, Some("testkey"));
         assert_eq!(torrents.len(), 2);
-        assert_eq!(torrents[0].tracker, "Nyaa");
-        assert_eq!(torrents[1].tracker, "AB");
+        assert_eq!(torrents[0].tracker, Tracker::Nyaa);
+        assert_eq!(torrents[1].tracker, Tracker::AnimeBytes);
         assert!(
             torrents[1]
                 .download_url
@@ -578,6 +619,6 @@ mod tests {
         )];
         let torrents = ReleasesClient::entries_to_torrents(entries, None);
         assert_eq!(torrents.len(), 1);
-        assert_eq!(torrents[0].tracker, "Nyaa");
+        assert_eq!(torrents[0].tracker, Tracker::Nyaa);
     }
 }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -15,13 +15,19 @@ const DEBAND_TAG: &str = "Deband Required";
 pub struct ReleasesClient {
     http: Client,
     base_url: Url,
+    ab_passkey: Option<String>,
 }
 
 impl ReleasesClient {
-    pub fn new(http: Client) -> Result<Self> {
+    pub fn new(http: Client, ab_passkey: Option<&str>) -> Result<Self> {
         let base_url = Url::parse(RELEASES_BASE_URL)?;
 
-        Ok(Self { http, base_url })
+        let ab_passkey = ab_passkey.map(|k| k.to_string());
+        Ok(Self {
+            http,
+            base_url,
+            ab_passkey,
+        })
     }
 
     pub async fn search_torrents(&self, anilist_id: i64) -> Result<Vec<Torrent>, ReleasesError> {
@@ -34,7 +40,7 @@ impl ReleasesClient {
             })
             .await?;
 
-        let torrents = Self::entries_to_torrents(payload.items);
+        let torrents = Self::entries_to_torrents(payload.items, self.ab_passkey.as_deref());
 
         trace!(
             anilist_id,
@@ -53,7 +59,7 @@ impl ReleasesClient {
             })
             .await?;
 
-        let torrents = Self::entries_to_torrents(payload.items);
+        let torrents = Self::entries_to_torrents(payload.items, self.ab_passkey.as_deref());
 
         trace!(
             feed = "recent-public",
@@ -93,7 +99,8 @@ impl ReleasesClient {
         Ok(payload)
     }
 
-    fn entries_to_torrents(entries: Vec<EntryRecord>) -> Vec<Torrent> {
+    fn entries_to_torrents(entries: Vec<EntryRecord>, ab_passkey: Option<&str>) -> Vec<Torrent> {
+        let ab_enabled = ab_passkey.is_some();
         entries
             .into_iter()
             .flat_map(|entry| {
@@ -102,10 +109,14 @@ impl ReleasesClient {
                     expand.trs.into_iter().map(move |record| (al_id, record))
                 })
             })
-            .filter(|(_, record)| record.tracker == "Nyaa")
+            .filter(|(_, record)| {
+                record.tracker == "Nyaa" || (ab_enabled && record.tracker == "AB")
+            })
             .filter(|(_, record)| !record.tags.contains(&"Incomplete".to_string()))
-            .filter(|(_, record)| rewritten_download_url(record).is_some())
-            .map(|(al_id, record)| Torrent::from_record(record, al_id))
+            .filter_map(|(al_id, record)| {
+                let download_url = rewritten_download_url(&record, ab_passkey)?;
+                Some(Torrent::from_record(record, al_id, download_url))
+            })
             .collect()
     }
 
@@ -161,7 +172,7 @@ impl ReleasesClient {
                 let Some(al_id) = entry.al_id else { continue };
 
                 for record in expand.trs {
-                    if record.tracker != "Nyaa" {
+                    if record.tracker != "Nyaa" && record.tracker != "AB" {
                         continue;
                     }
 
@@ -207,6 +218,7 @@ pub struct Torrent {
     pub dual_audio: bool,
     pub tags: Vec<String>,
     pub anilist_id: Option<i64>,
+    pub tracker: String,
 }
 
 impl Torrent {
@@ -214,10 +226,9 @@ impl Torrent {
         self.tags.iter().any(|tag| tag == DEBAND_TAG)
     }
 
-    fn from_record(record: TorrentRecord, anilist_id: Option<i64>) -> Self {
-        let download_url = rewritten_download_url(&record).unwrap_or_else(|| record.url.clone());
+    fn from_record(record: TorrentRecord, anilist_id: Option<i64>, download_url: String) -> Self {
         let source_url = record.url.clone();
-
+        let tracker = record.tracker.clone();
         let size_bytes = record.files.iter().map(|f| f.length).sum::<u64>();
         Torrent {
             id: record.id,
@@ -235,6 +246,7 @@ impl Torrent {
             tags: record.tags,
             anilist_id,
             source_url,
+            tracker,
         }
     }
 }
@@ -276,15 +288,28 @@ fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
     OffsetDateTime::parse(&normalized, &Rfc3339).ok()
 }
 
-fn rewritten_download_url(record: &TorrentRecord) -> Option<String> {
-    extract_nyaa_id(record.url.as_str()).map(|id| format!("https://nyaa.si/download/{id}.torrent"))
+fn rewritten_download_url(record: &TorrentRecord, ab_passkey: Option<&str>) -> Option<String> {
+    if record.tracker == "AB" {
+        let passkey = ab_passkey?;
+        let id = extract_id(record.url.as_str(), Some(&record.tracker))?;
+        Some(format!(
+            "https://animebytes.tv/download.php?id={id}&passkey={passkey}"
+        ))
+    } else {
+        let id = extract_id(record.url.as_str(), None)?;
+        Some(format!("https://nyaa.si/download/{id}.torrent"))
+    }
 }
 
-fn extract_nyaa_id(url: &str) -> Option<&str> {
-    let needle = "/view/";
+fn extract_id<'a>(url: &'a str, tracker: Option<&str>) -> Option<&'a str> {
+    let needle = if tracker == Some("AB") {
+        "torrentid="
+    } else {
+        "/view/"
+    };
     let start = url.find(needle)? + needle.len();
     let rest = &url[start..];
-    let id = rest.split(['?', '#', '/']).next().unwrap_or("");
+    let id = rest.split(['?', '#', '/', '&']).next().unwrap_or("");
     if id.is_empty() || !id.chars().all(|ch| ch.is_ascii_digit()) {
         return None;
     }
@@ -320,6 +345,21 @@ mod tests {
         }
     }
 
+    fn make_ab_torrent_record(id: &str, torrentid: &str) -> TorrentRecord {
+        TorrentRecord {
+            id: id.to_string(),
+            url: format!("/torrents.php?id={}&torrentid={}", id, torrentid),
+            info_hash: None,
+            created: None,
+            updated: None,
+            is_best: false,
+            dual_audio: false,
+            tags: Vec::new(),
+            tracker: "AB".to_string(),
+            files: Vec::new(),
+        }
+    }
+
     fn make_file(length: u64) -> TorrentFile {
         TorrentFile { length }
     }
@@ -333,29 +373,56 @@ mod tests {
 
     #[test]
     fn parses_releases_base_url() {
-        ReleasesClient::new(crate::http::client().unwrap())
+        ReleasesClient::new(crate::http::client().unwrap(), None)
             .expect("client construction must succeed");
     }
 
     #[test]
     fn extracts_nyaa_id() {
-        assert_eq!(extract_nyaa_id("https://nyaa.si/view/12345"), Some("12345"));
         assert_eq!(
-            extract_nyaa_id("https://nyaa.si/view/12345?foo=bar"),
+            extract_id("https://nyaa.si/view/12345", None),
             Some("12345")
         );
         assert_eq!(
-            extract_nyaa_id("https://nyaa.si/view/12345#section"),
+            extract_id("https://nyaa.si/view/12345?foo=bar", None),
             Some("12345")
         );
         assert_eq!(
-            extract_nyaa_id("https://nyaa.si/view/12345/extra"),
+            extract_id("https://nyaa.si/view/12345#section", None),
             Some("12345")
         );
-        assert_eq!(extract_nyaa_id("https://nyaa.si/view/abc"), None);
-        assert_eq!(extract_nyaa_id("https://nyaa.si/view/12a45"), None);
-        assert_eq!(extract_nyaa_id("https://nyaa.si/something/12345"), None);
-        assert_eq!(extract_nyaa_id(""), None);
+        assert_eq!(
+            extract_id("https://nyaa.si/view/12345/extra", None),
+            Some("12345")
+        );
+        assert_eq!(extract_id("https://nyaa.si/view/abc", None), None);
+        assert_eq!(extract_id("https://nyaa.si/view/12a45", None), None);
+        assert_eq!(extract_id("https://nyaa.si/something/12345", None), None);
+        assert_eq!(extract_id("", None), None);
+    }
+
+    #[test]
+    fn extracts_ab_torrent_id() {
+        assert_eq!(
+            extract_id("/torrents.php?id=70543&torrentid=1143533", Some("AB")),
+            Some("1143533")
+        );
+        assert_eq!(
+            extract_id(
+                "/torrents.php?id=70543&torrentid=1143533&extra=1",
+                Some("AB")
+            ),
+            Some("1143533")
+        );
+        assert_eq!(
+            extract_id(
+                "/torrents.php?id=70543&torrentid=1143533#section",
+                Some("AB")
+            ),
+            Some("1143533")
+        );
+        assert_eq!(extract_id("/torrents.php?id=70543", Some("AB")), None);
+        assert_eq!(extract_id("", Some("AB")), None);
     }
 
     #[test]
@@ -376,7 +443,11 @@ mod tests {
             files: vec![make_file(100), make_file(200), make_file(300)],
             ..make_torrent_record("1")
         };
-        assert_eq!(Torrent::from_record(with_files, None).size_bytes, 600);
+        let download_url = "https://nyaa.si/download/1.torrent".to_string();
+        assert_eq!(
+            Torrent::from_record(with_files, None, download_url).size_bytes,
+            600
+        );
 
         let both_timestamps = TorrentRecord {
             created: Some("2024-01-01T00:00:00Z".to_string()),
@@ -384,8 +455,9 @@ mod tests {
             ..make_torrent_record("1")
         };
         let updated = OffsetDateTime::parse("2024-02-02T00:00:00Z", &Rfc3339).unwrap();
+        let download_url = "https://nyaa.si/download/1.torrent".to_string();
         assert_eq!(
-            Torrent::from_record(both_timestamps, None).published,
+            Torrent::from_record(both_timestamps, None, download_url).published,
             Some(updated)
         );
 
@@ -395,8 +467,9 @@ mod tests {
             ..make_torrent_record("1")
         };
         let created = OffsetDateTime::parse("2024-01-01T00:00:00Z", &Rfc3339).unwrap();
+        let download_url = "https://nyaa.si/download/1.torrent".to_string();
         assert_eq!(
-            Torrent::from_record(only_created, None).published,
+            Torrent::from_record(only_created, None, download_url).published,
             Some(created)
         );
 
@@ -404,12 +477,21 @@ mod tests {
             url: "https://nyaa.si/view/9876".to_string(),
             ..make_torrent_record("1")
         };
-        let torrent = Torrent::from_record(with_nyaa_url, None);
-        assert_eq!(
-            torrent.download_url,
-            "https://nyaa.si/download/9876.torrent"
-        );
+        let download_url = "https://nyaa.si/download/9876.torrent".to_string();
+        let torrent = Torrent::from_record(with_nyaa_url, None, download_url.clone());
+        assert_eq!(torrent.download_url, download_url);
         assert_eq!(torrent.source_url, "https://nyaa.si/view/9876");
+        assert_eq!(torrent.tracker, "Nyaa");
+
+        let with_ab_url = make_ab_torrent_record("70543", "1143533");
+        let ab_download_url =
+            "https://animebytes.tv/download.php?id=1143533&passkey=test".to_string();
+        let torrent = Torrent::from_record(with_ab_url, None, ab_download_url);
+        assert_eq!(torrent.tracker, "AB");
+        assert_eq!(
+            torrent.source_url,
+            "/torrents.php?id=70543&torrentid=1143533"
+        );
     }
 
     #[test]
@@ -424,7 +506,7 @@ mod tests {
                 },
             ],
         )];
-        let torrents = ReleasesClient::entries_to_torrents(with_other_tracker);
+        let torrents = ReleasesClient::entries_to_torrents(with_other_tracker, None);
         assert_eq!(torrents.len(), 1);
         assert_eq!(torrents[0].id, "1");
 
@@ -438,7 +520,7 @@ mod tests {
                 },
             ],
         )];
-        let torrents = ReleasesClient::entries_to_torrents(with_incomplete_tag);
+        let torrents = ReleasesClient::entries_to_torrents(with_incomplete_tag, None);
         assert_eq!(torrents.len(), 1);
         assert_eq!(torrents[0].id, "1");
 
@@ -452,12 +534,48 @@ mod tests {
                 },
             ],
         )];
-        let torrents = ReleasesClient::entries_to_torrents(with_bad_url);
+        let torrents = ReleasesClient::entries_to_torrents(with_bad_url, None);
         assert_eq!(torrents.len(), 1);
         assert_eq!(torrents[0].id, "1");
 
         let single = vec![make_entry(Some(12345), vec![make_torrent_record("1")])];
-        let torrents = ReleasesClient::entries_to_torrents(single);
+        let torrents = ReleasesClient::entries_to_torrents(single, None);
         assert_eq!(torrents[0].anilist_id, Some(12345));
+    }
+
+    #[test]
+    fn ab_entries_included_with_passkey() {
+        let entries = vec![make_entry(
+            Some(42),
+            vec![
+                make_torrent_record("1"),
+                make_ab_torrent_record("70543", "1143533"),
+            ],
+        )];
+        let torrents = ReleasesClient::entries_to_torrents(entries, Some("testkey"));
+        assert_eq!(torrents.len(), 2);
+        assert_eq!(torrents[0].tracker, "Nyaa");
+        assert_eq!(torrents[1].tracker, "AB");
+        assert!(
+            torrents[1]
+                .download_url
+                .contains("animebytes.tv/download.php")
+        );
+        assert!(torrents[1].download_url.contains("id=1143533"));
+        assert!(torrents[1].download_url.contains("passkey=testkey"));
+    }
+
+    #[test]
+    fn ab_entries_excluded_without_passkey() {
+        let entries = vec![make_entry(
+            Some(42),
+            vec![
+                make_torrent_record("1"),
+                make_ab_torrent_record("70543", "1143533"),
+            ],
+        )];
+        let torrents = ReleasesClient::entries_to_torrents(entries, None);
+        assert_eq!(torrents.len(), 1);
+        assert_eq!(torrents[0].tracker, "Nyaa");
     }
 }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -227,7 +227,11 @@ impl Torrent {
     }
 
     fn from_record(record: TorrentRecord, anilist_id: Option<i64>, download_url: String) -> Self {
-        let source_url = record.url.clone();
+        let source_url = if record.tracker == "AB" && record.url.starts_with('/') {
+            format!("https://animebytes.tv{}", record.url)
+        } else {
+            record.url.clone()
+        };
         let tracker = record.tracker.clone();
         let size_bytes = record.files.iter().map(|f| f.length).sum::<u64>();
         Torrent {
@@ -291,9 +295,9 @@ fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
 fn rewritten_download_url(record: &TorrentRecord, ab_passkey: Option<&str>) -> Option<String> {
     if record.tracker == "AB" {
         let passkey = ab_passkey?;
-        let id = extract_id(record.url.as_str(), Some(&record.tracker))?;
+        let torrentid = extract_id(record.url.as_str(), Some(&record.tracker))?;
         Some(format!(
-            "https://animebytes.tv/download.php?id={id}&passkey={passkey}"
+            "https://animebytes.tv/torrent/{torrentid}/download/{passkey}"
         ))
     } else {
         let id = extract_id(record.url.as_str(), None)?;
@@ -485,12 +489,12 @@ mod tests {
 
         let with_ab_url = make_ab_torrent_record("70543", "1143533");
         let ab_download_url =
-            "https://animebytes.tv/download.php?id=1143533&passkey=test".to_string();
+            "https://animebytes.tv/torrent/1143533/download/test".to_string();
         let torrent = Torrent::from_record(with_ab_url, None, ab_download_url);
         assert_eq!(torrent.tracker, "AB");
         assert_eq!(
             torrent.source_url,
-            "/torrents.php?id=70543&torrentid=1143533"
+            "https://animebytes.tv/torrents.php?id=70543&torrentid=1143533"
         );
     }
 
@@ -559,10 +563,8 @@ mod tests {
         assert!(
             torrents[1]
                 .download_url
-                .contains("animebytes.tv/download.php")
+                .contains("animebytes.tv/torrent/1143533/download/testkey")
         );
-        assert!(torrents[1].download_url.contains("id=1143533"));
-        assert!(torrents[1].download_url.contains("passkey=testkey"));
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@ use crate::anilist::{AniListClient, AniListError, MediaFormat};
 use crate::config::{AnimePreference, AppConfig};
 use crate::mapping::{PlexAniBridgeMappings, TvdbMapping, parse_season_key};
 use crate::radarr::{RadarrClient, RadarrError};
-use crate::releases::{ReleasesClient, ReleasesError, Torrent};
+use crate::releases::{ReleasesClient, ReleasesError, Torrent, Tracker};
 use crate::sonarr::{SonarrClient, SonarrError};
 use crate::torznab::{self, ANIME_CATEGORY, MOVIE_CATEGORY, TorznabItem};
 use thiserror::Error;
@@ -13,12 +13,14 @@ use tracing::{debug, info, trace, warn};
 /// Upper bound on items returned in a single torznab response.
 const MAX_RESPONSE_ITEMS: usize = 100;
 
-fn priority_seeders(tracker: &str, preferred: bool) -> u32 {
+/// Seeder value to use for a torrent based on its tracker and preference.
+/// A value needs to be 10x greater than the next lower value for Sonarr/Radarr to prioritize it.
+fn priority_seeders(tracker: Tracker, preferred: bool) -> u32 {
     match (tracker, preferred) {
-        ("AB", true) => 10000,
-        ("AB", false) => 100,
-        (_, true) => 1000,
-        _ => 10,
+        (Tracker::AnimeBytes, true) => 10000,
+        (Tracker::Nyaa, true) => 1000,
+        (Tracker::AnimeBytes, false) => 100,
+        (Tracker::Nyaa, false) => 10,
     }
 }
 
@@ -594,7 +596,7 @@ impl SearchService {
             .into_iter()
             .filter(|release| !self.skip_due_to_deband(release))
             .map(|release| {
-                let seeders = priority_seeders(&release.tracker, release.is_best);
+                let seeders = priority_seeders(release.tracker, release.is_best);
                 self.build_torznab_item(release, title.clone(), categories.clone(), seeders)
             })
             .collect()
@@ -617,7 +619,7 @@ impl SearchService {
             .into_iter()
             .zip(priorities)
             .map(|(release, preferred)| {
-                let seeders = priority_seeders(&release.tracker, preferred);
+                let seeders = priority_seeders(release.tracker, preferred);
                 self.build_torznab_item(release, title.clone(), categories.clone(), seeders)
             })
             .collect()

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,6 +13,15 @@ use tracing::{debug, info, trace, warn};
 /// Upper bound on items returned in a single torznab response.
 const MAX_RESPONSE_ITEMS: usize = 100;
 
+fn priority_seeders(tracker: &str, preferred: bool) -> u32 {
+    match (tracker, preferred) {
+        ("AB", true) => 10000,
+        ("AB", false) => 100,
+        (_, true) => 1000,
+        _ => 10,
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ServiceError {
     #[error("{0:#}")]
@@ -584,7 +593,10 @@ impl SearchService {
         torrents
             .into_iter()
             .filter(|release| !self.skip_due_to_deband(release))
-            .map(|release| self.build_torznab_item(release, title.clone(), categories.clone(), 100))
+            .map(|release| {
+                let seeders = priority_seeders(&release.tracker, release.is_best);
+                self.build_torznab_item(release, title.clone(), categories.clone(), seeders)
+            })
             .collect()
     }
 
@@ -605,7 +617,7 @@ impl SearchService {
             .into_iter()
             .zip(priorities)
             .map(|(release, preferred)| {
-                let seeders = if preferred { 1000 } else { 100 };
+                let seeders = priority_seeders(&release.tracker, preferred);
                 self.build_torznab_item(release, title.clone(), categories.clone(), seeders)
             })
             .collect()


### PR DESCRIPTION
Adding support for AnimeBytes:

- `AB_PASSKEY` env var - must be set to include AB releases
- AB download URLs: `/torrent/{torrentid}/download/{passkey}`
- AB releases prioritized by seeders amount (AB 10000 best / 100 alt vs Nyaa 1000 / 10)
- `extract_id` generalized to handle both Nyaa (`/view/`) and AB (`torrentid=`) URL patterns
- `tracker` field added to `Torrent` for priority differentiation
- `resolve_anilist_ids_for_torrents` now includes AB records
- All changes require the passkey to be set, without `AB_PASSKEY`, behavior is identical to before