### PR TITLE
perf: keep torrent file count instead of the file list

### DIFF
--- a/src/releases.rs
+++ b/src/releases.rs
@@ -108,7 +108,7 @@ impl ReleasesClient {
                 if !tracker.is_enabled(ab_passkey) {
                     return None;
                 }
-                if record.tags.contains(&"Incomplete".to_string()) {
+                if record.tags.iter().any(|tag| tag == "Incomplete") {
                     return None;
                 }
                 let download_url = tracker.download_url(&record.url, ab_passkey)?;
@@ -205,7 +205,7 @@ pub struct Torrent {
     pub source_url: String,
     pub info_hash: Option<String>,
     pub published: Option<OffsetDateTime>,
-    pub files: Vec<TorrentFile>,
+    pub file_count: usize,
     pub size_bytes: u64,
     pub is_best: bool,
     pub dual_audio: bool,
@@ -232,7 +232,7 @@ impl Torrent {
                 .as_deref()
                 .and_then(parse_timestamp)
                 .or_else(|| record.created.as_deref().and_then(parse_timestamp)),
-            files: record.files,
+            file_count: record.files.len(),
             size_bytes,
             is_best: record.is_best,
             dual_audio: record.dual_audio,
@@ -264,8 +264,8 @@ struct TorrentRecord {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct TorrentFile {
-    pub length: u64,
+struct TorrentFile {
+    length: u64,
 }
 
 fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -176,7 +176,7 @@ mod tests {
             source_url: String::new(),
             info_hash: None,
             published: None,
-            files: Vec::new(),
+            file_count: 0,
             size_bytes: size,
             is_best: false,
             dual_audio: false,

--- a/src/service.rs
+++ b/src/service.rs
@@ -169,7 +169,7 @@ impl SearchService {
 
         let torrents: Vec<Torrent> = collected
             .into_iter()
-            .filter(|item| item.files.len() > 1)
+            .filter(|item| item.file_count > 1)
             .filter(|item| !self.is_excluded(item))
             .collect();
         let total = torrents.len();
@@ -391,7 +391,7 @@ impl SearchService {
 
             let include = match &media.format {
                 MediaFormat::Movie => true,
-                format if self.format_allowed(format) => torrent.files.len() > 1,
+                format if self.format_allowed(format) => torrent.file_count > 1,
                 _ => false,
             };
 


### PR DESCRIPTION
The per-file records were only ever used for a length sum and a files.len() > 1 check.

So just sum at construction which avoids creating a new Vec for every torrent.